### PR TITLE
Dont't watch node_modules in the compile dir

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var runSequence = require('run-sequence');
 requireDir( './gulp' );
 
 function watchAndRebuild() {
-	gulp.watch( ['./compile/**/*'], [ 'build' ] );
+	gulp.watch( ['./compile/**/*', '!./compile/node_modules/**/*'], [ 'build' ] );
 }
 
 function watchAndRecompile() {


### PR DESCRIPTION
@airtoxin based on your comment and my finding that the maximum `ulimit` is `10240`, I thought it would be a good idea to ignore the `node_modules` packages when watching the `compile` directory.

Closes #13 
