### PR TITLE
Setup babel + eslint + jscs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 build/*
 cache/*
 compile/*
+
+.eslintrc
+.jscsrc

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Electron app with React.js
 To call Electron's api, it is necessary to use window.require because, browserify rewrites require statement.
 
 ex) `var remote = window.require( 'remote' );`
+
+## Refactoring
+
+Run `npm run refactor` to refactor the code in accordance to [jscs preset](http://jscs.info/overview#presets) specified in the `.jscsrc` file.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,23 @@ ex) `var remote = window.require( 'remote' );`
 ## Refactoring
 
 Run `npm run refactor` to refactor the code in accordance to [jscs preset](http://jscs.info/overview#presets) specified in the `.jscsrc` file.
+
+## Linting
+
+Run `npm run lint` to run a linter through the codebase. The linter will check
+the codebase as specified in the [configuration file named `.eslintrc`](http://eslint.org/docs/user-guide/configuring). Fix all reported
+errors prior to committing code.
+
+An example of a `.eslintrc` follows:
+
+```json
+{
+  "ecmaFeatures": {
+    "blockBindings": true,
+    "jsx": true
+  },
+  "rules": {
+    "semi": 2
+  }
+}
+```

--- a/boot.js
+++ b/boot.js
@@ -1,0 +1,3 @@
+require('babel/register');
+
+require('./index.js');

--- a/component/app.js
+++ b/component/app.js
@@ -1,9 +1,9 @@
-( function () {
-	var React = require( 'react' ),
-		Main = require( './main/Main.js' );
-	var remote = window.require( 'remote' );
+(function() {
+  var React = require('react'),
+  Main = require('./main/Main.js');
+  var remote = window.require('remote');
 
-	window.React = React;
+  window.React = React;
 
-	React.render( <Main />, document.body );
-} )();
+  React.render(<Main />, document.body);
+})();

--- a/component/main/Main.js
+++ b/component/main/Main.js
@@ -1,14 +1,14 @@
-var React = require( 'react' );
+var React = require('react');
 
-var Main = React.createClass( {
-	displayName: 'Main',
-	render: function() {
-		return (
-			<div>
-				<p>main content</p>
-			</div>
-		);
-	}
-} );
+var Main = React.createClass({
+  displayName: 'Main',
+  render: function() {
+    return (
+    <div>
+				    <p>main content</p>
+			    </div>
+    );
+  },
+});
 
 module.exports = Main;

--- a/gulp/atom.js
+++ b/gulp/atom.js
@@ -1,13 +1,13 @@
-var gulp = require( 'gulp' );
-var atom = require( 'gulp-atom' );
+var gulp = require('gulp');
+var atom = require('gulp-atom');
 
-gulp.task( 'atom', function () {
-	atom( {
-		srcPath: './compile',
-		releasePath: './build',
-		cachePath: './cache',
-		version: 'v0.30.2',
-		rebuild: false,
-		platforms: [ 'darwin-x64' ]
-	} );
-} );
+gulp.task('atom', function() {
+  atom({
+    srcPath: './compile',
+    releasePath: './build',
+    cachePath: './cache',
+    version: 'v0.30.2',
+    rebuild: false,
+    platforms: ['darwin-x64'],
+  });
+});

--- a/gulp/eslint.js
+++ b/gulp/eslint.js
@@ -1,0 +1,10 @@
+var gulp = require( 'gulp' );
+var eslint = require( 'gulp-eslint' );
+var files_matcher = [ 'component/**/*.js', 'gulp/**/*.js', '*.js' ];
+
+gulp.task( 'lint', function() {
+  return gulp.src(files_matcher, { base: './' })
+    .pipe(eslint())
+    .pipe(eslint.format());
+    //.pipe(eslint.failAfterError());
+} );

--- a/gulp/refactor.js
+++ b/gulp/refactor.js
@@ -1,6 +1,6 @@
 var gulp = require( 'gulp' );
 var jscs = require( 'gulp-jscs' );
-var files_matcher = [ './component/**/*.js', './*.js' ];
+var files_matcher = [ 'component/**/*.js', 'gulp/**/*.js', '*.js' ];
 
 gulp.task( 'check-syntax', function() { 
   return gulp.src(files_matcher)
@@ -9,10 +9,10 @@ gulp.task( 'check-syntax', function() {
 } );
 
 gulp.task( 'refactor', function() {
-  return gulp.src(files_matcher)
-    .pipe(jscs({
+  return gulp.src(files_matcher, { base: './' })
+    .pipe(jscs({ 
       fix: true
     }))
-    .pipe(gulp.dest('./'));
+    .pipe(gulp.dest('.'));
 } );
 

--- a/gulp/refactor.js
+++ b/gulp/refactor.js
@@ -1,0 +1,17 @@
+var gulp = require( 'gulp' );
+var jscs = require( 'gulp-jscs' );
+
+gulp.task( 'style', function() { 
+  return gulp.src([ './component/**/*.js', './index.js' ])
+    .pipe(jscs())
+    .pipe(jscs.reporter());
+} );
+
+gulp.task( 'refactor', function() {
+  return gulp.src([ './**/*.js' ])
+    .pipe(jscs({
+      fix: true
+    }))
+    .pipe(gulp.dest('./'));
+} );
+

--- a/gulp/refactor.js
+++ b/gulp/refactor.js
@@ -1,14 +1,15 @@
 var gulp = require( 'gulp' );
 var jscs = require( 'gulp-jscs' );
+var files_matcher = [ './component/**/*.js', './*.js' ];
 
-gulp.task( 'style', function() { 
-  return gulp.src([ './component/**/*.js', './index.js' ])
+gulp.task( 'check-syntax', function() { 
+  return gulp.src(files_matcher)
     .pipe(jscs())
     .pipe(jscs.reporter());
 } );
 
 gulp.task( 'refactor', function() {
-  return gulp.src([ './**/*.js' ])
+  return gulp.src(files_matcher)
     .pipe(jscs({
       fix: true
     }))

--- a/gulp/through.js
+++ b/gulp/through.js
@@ -1,6 +1,6 @@
 var gulp = require( 'gulp' );
 
 gulp.task( 'through', function () {
-	return gulp.src( [ './index.html', './index.js' ] )
+	return gulp.src( [ './index.html', './index.js', './boot.js' ] )
 		.pipe( gulp.dest( './compile' ) );
 } );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task( 'watch-all', function () {
 } );
 
 gulp.task( 'watch-compile-build', function () {
-  runSequence('compile', 'build', 'watch-all')
+  runSequence('compile', 'build', 'watch-all');
 } );
 
 gulp.task( 'watch-compile', [ 'build' ], watchAndRecompile );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,9 @@ gulp.task( 'watch-all', function () {
 	watchAndRebuild();
 } );
 
-gulp.task( 'watch-compile-build', runSequence('compile', 'build', 'watch-all') );
+gulp.task( 'watch-compile-build', function () {
+  runSequence('compile', 'build', 'watch-all')
+} );
 
 gulp.task( 'watch-compile', [ 'build' ], watchAndRecompile );
 gulp.task( 'watch-build', [ 'build' ], watchAndRebuild );

--- a/index.js
+++ b/index.js
@@ -132,22 +132,22 @@ app.on('ready', function() {
 			submenu: [{
 				label: 'Learn More',
 				click: function() {
-					require('shell').openExternal('http://electron.atom.io')
+					require('shell').openExternal('http://electron.atom.io');
 				}
 			}, {
 				label: 'Documentation',
 				click: function() {
-					require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme')
+					require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme');
 				}
 			}, {
 				label: 'Community Discussions',
 				click: function() {
-					require('shell').openExternal('https://discuss.atom.io/c/electron')
+					require('shell').openExternal('https://discuss.atom.io/c/electron');
 				}
 			}, {
 				label: 'Search Issues',
 				click: function() {
-					require('shell').openExternal('https://github.com/atom/electron/issues')
+					require('shell').openExternal('https://github.com/atom/electron/issues');
 				}
 			}]
 		}];
@@ -193,22 +193,22 @@ app.on('ready', function() {
 			submenu: [{
 				label: 'Learn More',
 				click: function() {
-					require('shell').openExternal('http://electron.atom.io')
+					require('shell').openExternal('http://electron.atom.io');
 				}
 			}, {
 				label: 'Documentation',
 				click: function() {
-					require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme')
+					require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme');
 				}
 			}, {
 				label: 'Community Discussions',
 				click: function() {
-					require('shell').openExternal('https://discuss.atom.io/c/electron')
+					require('shell').openExternal('https://discuss.atom.io/c/electron');
 				}
 			}, {
 				label: 'Search Issues',
 				click: function() {
-					require('shell').openExternal('https://github.com/atom/electron/issues')
+					require('shell').openExternal('https://github.com/atom/electron/issues');
 				}
 			}]
 		}];

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use babel';
+
 var app = require('app');
 var Menu = require('menu');
 var MenuItem = require('menu-item');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Electron(Atom-Shell) app using React.js",
   "main": "index.js",
   "scripts": {
-    "start": "gulp"
+    "start": "gulp",
+    "refactor": "gulp refactor"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "devDependencies": {
-    "babel": "^5.8.23"
+    "babel": "^5.8.23",
+    "gulp-jscs": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "gulp",
+    "syntax": "gulp check-syntax",
     "refactor": "gulp refactor"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,7 @@
     "run-sequence": "^1.1.2",
     "vinyl-source-stream": "^1.1.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "babel": "^5.8.23"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "gulp",
+    "lint": "gulp lint",
     "syntax": "gulp check-syntax",
     "refactor": "gulp refactor"
   },
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "babel": "^5.8.23",
+    "gulp-eslint": "^1.0.0",
     "gulp-jscs": "^3.0.0"
   }
 }


### PR DESCRIPTION
Setup `eslint` and `jscs` in order to allow
`npm run lint` to detect issues detected by the linter
`npm run syntax-check` to detect issues detected by jscs
and `npm run refactor` to allow jscs to modfify the source to conform to the specific styleguide.
